### PR TITLE
NSLocationAlwaysAndWhenInUseUsageDescriptionを追加

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,6 +30,8 @@
 	<string>This App will allow you to search for and connect to devices on the network you are using.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Requests are made for the purpose of taking photos and videos for display and use in the application.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>To use this application, please select "Always allow" to use the service comfortably.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>If you allow, you can use the service comfortably based on your location information. Your location information will not be shared with others.</string>
 	<key>NSUserTrackingUsageDescription</key>

--- a/ios/Runner/ja.lproj/InfoPlist.strings
+++ b/ios/Runner/ja.lproj/InfoPlist.strings
@@ -10,4 +10,5 @@ NSUserTrackingUsageDescription = "「許可」するとお客様のデータが�
 NSLocationWhenInUseUsageDescription = "「許可」すると位置情報を元に、サービスを快適にご利用いただけます。あなたの位置情報が他人にシェアされることはありません。";
 NSCameraUsageDescription = "アプリに表示・使用するための写真や動画を撮影する目的でリクエストします。";
 NSLocalNetworkUsageDescription = "このAppで使用中のネットワークのデバイス検索および接続ができるようになります。";
+NSLocationAlwaysAndWhenInUseUsageDescription = "このアプリの利用には、「常に許可」を選択するとサービスを快適にご利用いただけます。";
 


### PR DESCRIPTION
## 対応したこと

- NSLocationAlwaysAndWhenInUseUsageDescriptionを追加

## 関連資料
https://qiita.com/gaussbeam/items/96612baed85edb8f7c6d

## 残タスク
ユーザー情報登録ページのNull Check Error

## 画面キャプチャ

