### PR TITLE
flutter_background_geolocationクラスのメソッドを一時停止

### DIFF
--- a/lib/features/google_map/fetch_all_markers.dart
+++ b/lib/features/google_map/fetch_all_markers.dart
@@ -77,8 +77,8 @@ final fetchAllMarkersProvider =
             ),
           );
         }
-        read(flutterBackgroundGeolocationServiceProvider)
-            .addGeofences(geofences);
+        // read(flutterBackgroundGeolocationServiceProvider)
+        //     .addGeofences(geofences);
         return list;
       });
       debugPrint('全マーカーを取得しました。');

--- a/lib/pages/map/map_page.dart
+++ b/lib/pages/map/map_page.dart
@@ -75,9 +75,9 @@ class MapPage extends HookConsumerWidget {
       [],
     );
 
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      watch(flutterBackgroundGeolocationServiceProvider).eventOnGeofence();
-    });
+    // WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+    //   watch(flutterBackgroundGeolocationServiceProvider).eventOnGeofence();
+    // });
 
     final currentSpot = watch(currentSpotProvider);
     final selectedMapType = watch(selectedMapTypeProvider);

--- a/lib/pages/map/map_page.dart
+++ b/lib/pages/map/map_page.dart
@@ -8,7 +8,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:search_roof_top_app/features/google_map/google_map.dart';
 import 'package:search_roof_top_app/features/setting/setting.dart';
 import 'package:search_roof_top_app/pages/map/components/map_components.dart';
-import 'package:search_roof_top_app/utils/utils.dart';
+// import 'package:search_roof_top_app/utils/utils.dart';
 import 'package:search_roof_top_app/widgets/widgets.dart';
 
 class MapPage extends HookConsumerWidget {


### PR DESCRIPTION
## 対応したこと

- flutter_background_geolocationクラスのメソッドを一時停止

## 関連資料
特になし

## 残タスク
特になし
## 画面キャプチャ
特になし