### PR TITLE
Dialogを扱うProviderでcontextへの依存をなくす

### DIFF
--- a/lib/features/google_map/fetch_all_markers.dart
+++ b/lib/features/google_map/fetch_all_markers.dart
@@ -10,11 +10,9 @@ import 'package:search_roof_top_app/utils/utils.dart';
 
 final showModalProvider = StateProvider.autoDispose<
     Future<void> Function({
-      required BuildContext context,
       required MarkerData markerData,
     })>(
   (ref) => ({
-    required context,
     required markerData,
   }) async {
     await showModalBottomSheet<void>(
@@ -24,9 +22,9 @@ final showModalProvider = StateProvider.autoDispose<
           topRight: Radius.circular(16),
         ),
       ),
-      context: context,
+      context: ref.read(navigatorKeyProvider).currentContext!,
       elevation: 0,
-      builder: (context) {
+      builder: (_) {
         return MarkerDetailModal(
           markerData: markerData,
         );
@@ -35,9 +33,8 @@ final showModalProvider = StateProvider.autoDispose<
   },
 );
 
-final fetchAllMarkersProvider =
-    StreamProvider.family<List<Marker>, BuildContext>(
-  (ref, context) async* {
+final fetchAllMarkersProvider = StreamProvider<List<Marker>>(
+  (ref) async* {
     final read = ref.read;
     final isNetworkCheck = await isNetworkConnected();
     try {
@@ -58,12 +55,9 @@ final fetchAllMarkersProvider =
                 snippet: marker.description,
               ),
               consumeTapEvents: true,
-              onTap: () {
-                ref.read(showModalProvider).call(
-                      context: context,
-                      markerData: marker,
-                    );
-              },
+              onTap: () => read(showModalProvider).call(
+                markerData: marker,
+              ),
             ),
           );
           geofences.add(

--- a/lib/features/google_map/search_markers.dart
+++ b/lib/features/google_map/search_markers.dart
@@ -5,17 +5,16 @@ import 'package:search_roof_top_app/features/google_map/google_map.dart';
 import 'package:search_roof_top_app/models/marker_data.dart';
 import 'package:search_roof_top_app/repositories/marker/marker_repository_impl.dart';
 import 'package:search_roof_top_app/utils/utils.dart';
-import 'package:tuple/tuple.dart';
 
-final searchMarkersProvider = FutureProvider.autoDispose
-    .family<List<Marker>?, Tuple2<String, BuildContext>>(
-  (ref, param) async {
+final searchMarkersProvider =
+    FutureProvider.autoDispose.family<List<Marker>?, String>(
+  (ref, query) async {
     final read = ref.read;
     final isNetworkCheck = await isNetworkConnected();
     try {
       final list = <Marker>[];
       await read(markerRepositoryImplProvider)
-          .searchMarkers(query: param.item1)
+          .searchMarkers(query: query)
           .then((value) {
         for (final document in value) {
           list.add(
@@ -31,10 +30,7 @@ final searchMarkersProvider = FutureProvider.autoDispose
               ),
               consumeTapEvents: true,
               onTap: () {
-                ref.read(showModalProvider).call(
-                      context: param.item2,
-                      markerData: document,
-                    );
+                read(showModalProvider).call(markerData: document);
               },
             ),
           );
@@ -58,13 +54,13 @@ final searchMarkersProvider = FutureProvider.autoDispose
 );
 
 final searchMarkerDataProvider = FutureProvider.autoDispose
-    .family<List<MarkerData>?, Tuple2<String, BuildContext>>(
-  (ref, param) async {
+    .family<List<MarkerData>?, String>(
+  (ref, query) async {
     final read = ref.read;
     final isNetworkCheck = await isNetworkConnected();
     try {
       final response = await read(markerRepositoryImplProvider)
-          .searchMarkers(query: param.item1);
+          .searchMarkers(query: query);
       debugPrint('全マーカーを取得しました。');
       return response;
     } on AppException catch (e) {

--- a/lib/pages/map/components/create_marker_dialog.dart
+++ b/lib/pages/map/components/create_marker_dialog.dart
@@ -37,7 +37,7 @@ class CreateMarkerDialog extends HookConsumerWidget {
 
     final isAuthenticated = ref.read(isAuthenticatedProvider);
     final selectedMapType = ref.watch(selectedMapTypeProvider);
-    final markers = ref.watch(fetchAllMarkersProvider(context));
+    final markers = ref.watch(fetchAllMarkersProvider);
     final tappedPosition = useState<LatLng?>(null);
 
     WidgetsBinding.instance.addPostFrameCallback(

--- a/lib/pages/map/map_page.dart
+++ b/lib/pages/map/map_page.dart
@@ -84,7 +84,7 @@ class MapPage extends HookConsumerWidget {
           ? const Center(
               child: CircularProgressIndicator(),
             )
-          : watch(fetchAllMarkersProvider(context)).when(
+          : watch(fetchAllMarkersProvider).when(
               data: (markers) {
                 return GoogleMap(
                   onMapCreated: onMapCreated,

--- a/lib/pages/profile/components/user_post_card.dart
+++ b/lib/pages/profile/components/user_post_card.dart
@@ -154,10 +154,7 @@ class UserPostCard extends HookConsumerWidget {
                   mapController
                       ?.showMarkerInfoWindow(MarkerId(markerData.markerId));
 
-                  ref.read(showModalProvider).call(
-                        context: context,
-                        markerData: markerData,
-                      );
+                  read(showModalProvider).call(markerData: markerData);
                 },
                 icon: const Icon(Icons.pin_drop_outlined),
               ),

--- a/lib/widgets/search_bar/float_search_bar.dart
+++ b/lib/widgets/search_bar/float_search_bar.dart
@@ -4,7 +4,6 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:material_floating_search_bar_2/material_floating_search_bar_2.dart';
 import 'package:search_roof_top_app/features/google_map/google_map.dart';
 import 'package:search_roof_top_app/widgets/widgets.dart';
-import 'package:tuple/tuple.dart';
 
 class FloatSearchBar extends HookConsumerWidget {
   const FloatSearchBar({super.key});
@@ -58,9 +57,7 @@ class FloatSearchBar extends HookConsumerWidget {
               children: query.value.isNotEmpty
                   ? ref
                       .watch(
-                        searchMarkerDataProvider(
-                          Tuple2(query.value, context),
-                        ),
+                        searchMarkerDataProvider(query.value),
                       )
                       .when(
                         data: (markers) {
@@ -78,9 +75,7 @@ class FloatSearchBar extends HookConsumerWidget {
                           ErrorPage(
                             error: error,
                             onTapReload: () => ref.invalidate(
-                              searchMarkerDataProvider(
-                                Tuple2(query.value, context),
-                              ),
+                              searchMarkerDataProvider(query.value),
                             ),
                           ),
                         ],

--- a/lib/widgets/search_bar/search_result_card.dart
+++ b/lib/widgets/search_bar/search_result_card.dart
@@ -34,12 +34,10 @@ class SearchResultCard extends HookConsumerWidget {
         ),
         tileColor: ColorName.white,
         title: Text(markerData.title),
-        subtitle: Expanded(
-          child: Text(
-            markerData.description,
-            overflow: TextOverflow.ellipsis,
-            maxLines: 1,
-          ),
+        subtitle: Text(
+          markerData.description,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
         ),
         trailing: SvgPicture.asset(
           Assets.icons.rightArrow,
@@ -68,10 +66,7 @@ class SearchResultCard extends HookConsumerWidget {
           mapController?.showMarkerInfoWindow(
             MarkerId(markerData.markerId),
           );
-          ref.read(showModalProvider).call(
-                context: context,
-                markerData: markerData,
-              );
+          read(showModalProvider).call(markerData: markerData);
         },
       ),
     );


### PR DESCRIPTION
## 対応したこと

- Dialogを扱うProviderでcontextへの依存をなくす
- 検索ページのカード内レイアウトを修正

## 関連資料
https://zenn.dev/flutteruniv_dev/articles/20221214-090833-flutter-async-value#%E3%81%A9%E3%81%93%E3%81%8B%E3%82%89%E3%81%A7%E3%82%82%E3%83%80%E3%82%A4%E3%82%A2%E3%83%AD%E3%82%B0%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B

## 残タスク
特になし

## 画面キャプチャ
特になし